### PR TITLE
Create odin.php config file and add login_email setting

### DIFF
--- a/config/odin.php
+++ b/config/odin.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Login email default value
+    |--------------------------------------------------------------------------
+    |
+    | Default value for the email field displayed in the login form.
+    |
+    */
+
+    'login_email' => env('LOGIN_EMAIL', ''),
+
+];

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -22,7 +22,7 @@
                 'label' => 'Email Address',
                 'html_type' => 'email',
                 'required' => true,
-                'default' => env('LOGIN_EMAIL'),
+                'default' => config('odin.login_email'),
             ])
 
             @include('maelstrom::inputs.secret', [


### PR DESCRIPTION
If you cache app configs with `artisan config:cache` the `.env` file is not parsed anymore and that cause `env('LOGIN_EMAIL')` on `auth/login.blade.php` to return a null string instead of the correct value.

To solve this problem, this pr creates a `odin.php` config file and moves into it the `LOGIN_EMAIL` setting.