### PR TITLE
Add tailwind config to remove unused CSS

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  purge: [
+    './resources/**/*.js',
+    './resources/**/*.blade.php',
+  ],
+  theme: {},
+  variants: {},
+  plugins: [],
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,7 @@ module.exports = {
   purge: [
     './resources/**/*.js',
     './resources/**/*.blade.php',
+    './node_modules/@maelstrom-cms/toolkit/**/*.js',
   ],
   theme: {},
   variants: {},


### PR DESCRIPTION
Using the config we can automatically remove unused css from the generated css file on production and reduce the size from 2mb to ~500Kib

**Before**:
```
/css/maelstrom.css  2.04 MiB       0  [emitted]  [big]  /js/maelstrom
```

**After**:
```
/css/maelstrom.css   496 KiB       0  [emitted]  [big]  /js/maelstrom
```

