### PR TITLE
feat: :children_crossing: Reverse time scale for response times (#32)

### DIFF
--- a/app/HasUptime.php
+++ b/app/HasUptime.php
@@ -123,6 +123,7 @@ trait HasUptime
                    'value' => $scan->response_time,
                ];
             })
+            ->reverse()
             ->values();
     }
 


### PR DESCRIPTION

This adresses #32 - For ltr, a time scale draws from oldest (left) to latest (right)