### PR TITLE
Allow adding and checking vhosts with path

### DIFF
--- a/app/HasRobots.php
+++ b/app/HasRobots.php
@@ -16,7 +16,8 @@ trait HasRobots
 
     public function getRobotsUrlAttribute()
     {
-        return $this->url . '/robots.txt';
+        parts = parse_url($this->url);
+        return sprintf('%s://%s/robots.txt', $parts['scheme'], $parts['host']);
     }
 
 }

--- a/app/Website.php
+++ b/app/Website.php
@@ -201,8 +201,6 @@ class Website extends Model
      */
     public function setUrlAttribute($value)
     {
-        $parts = parse_url($value);
-
-        $this->attributes['url'] = sprintf('%s://%s', $parts['scheme'], $parts['host']);
+        $this->attributes['url'] = $value;
     }
 }


### PR DESCRIPTION
Support for adding Domains / Vhosts like "https://example.com/health" while keeping the functionality of Robots and DNS check intact.

To reduce load on checked systems and support for checking sub-dir setups.