### PR TITLE
Add json status endpoint

### DIFF
--- a/app/Http/Controllers/StatusReportController.php
+++ b/app/Http/Controllers/StatusReportController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Website;
+use Illuminate\Http\Request;
+use App\Jobs\CertificateCheck;
+
+class StatusReportController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param Request $request
+     * @return array
+     */
+    public function __invoke(Request $request, Website $website)
+    {
+        $results = [];
+        foreach (Website::all() as $site) {
+            $results[$site->url]['uptime'] = $site->generateUptimeReport();
+            $results[$site->url]['ssl'] = $site->certificates()->latest()->first();
+            $results[$site->url]['dns'] = $site->last_dns_scans;
+            $results[$site->url]['robots'] = $site->last_robot_scans;
+        }
+
+        return $results;
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,8 @@ Route::middleware('auth')->group(function () {
     Route::put('edit-account', '\Maelstrom\Http\Controllers\EditAccountController@update');
     Route::post('logout', 'Auth\LoginController@logout')->name('maelstrom.logout');
 
+    Route::get('status', 'StatusReportController')->name('status');
+
     Route::post('websites/bulk', 'WebsiteController@bulk')->name('websites.bulk');
     Route::resource('websites', 'WebsiteController');
     Route::get('websites/{website}/robots', 'RobotCompareController')->name('robots');


### PR DESCRIPTION
Adds an json endpoint which returns the current state of all monitored websites.
We use it to include odin into existing monitoring infrastructure.